### PR TITLE
fix: replace deprecated toPromise() with firstValueFrom()

### DIFF
--- a/src/app/components/admin/products/product-form/product-form.component.ts
+++ b/src/app/components/admin/products/product-form/product-form.component.ts
@@ -1,6 +1,6 @@
 import { Router, ActivatedRoute } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
-import { Subscription, Observable } from 'rxjs';
+import { Subscription, Observable, firstValueFrom } from 'rxjs';
 import { AngularFireStorage } from '@angular/fire/compat/storage';
 import { finalize, map, take } from 'rxjs/operators';
 import { AuthService } from 'src/app/services/auth.service';
@@ -111,8 +111,8 @@ export class ProductFormComponent implements OnInit {
     }
   }
 
-  private async pushDownloadUrl(fileRef) {
-    this.product.gallery.push(await fileRef.getDownloadURL().toPromise());
+  private async pushDownloadUrl(fileRef: import('@angular/fire/compat/storage').AngularFireStorageReference) {
+    this.product.gallery.push(await firstValueFrom(fileRef.getDownloadURL()));
   }
 
   formatter = (x: { name: string }) => x.name;

--- a/src/app/components/products/product-preview/product-preview.component.ts
+++ b/src/app/components/products/product-preview/product-preview.component.ts
@@ -12,6 +12,7 @@ import { ContactService } from 'src/app/services/contact.service';
 import { Contact } from 'src/app/models/contact';
 import { ToastService } from 'src/app/services/toast.service';
 import { trigger, style, animate, transition } from '@angular/animations';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
     selector: 'product-preview',
@@ -76,7 +77,7 @@ export class ProductPreviewComponent {
     if (this.canSetPic) return;
 
     const productId = this.product.id;
-    const { ip, loc } = await this.locService.location$.toPromise();
+    const { ip, loc } = await firstValueFrom(this.locService.location$);
     const cartId = await this.cartService.getOrCreateCartId();
 
     const contact = new Contact(


### PR DESCRIPTION
## Summary
- Remplace `toPromise()` (déprécié depuis RxJS 7) par `firstValueFrom()` dans `product-form.component.ts` et `product-preview.component.ts`
- Typage fort ajouté pour le paramètre `fileRef` dans `pushDownloadUrl`

## Test plan
- [ ] Tester l'upload d'images dans le formulaire produit admin
- [ ] Tester l'envoi du formulaire de contact sur une fiche produit

🤖 Generated with [Claude Code](https://claude.com/claude-code)