### PR TITLE
fix: restrict Firestore security rules to authenticated users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,9 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
       
-      match /shopping-carts/{document=**} {
-      	allow read,write:if true;
+      match /shopping-carts/{cartId} {
+        allow read, write: if isSignedIn() && belongsTo(cartId);
+        allow read, write: if isAdmin();
       }
       
       match /users/{userId} {
@@ -20,9 +21,10 @@ service cloud.firestore {
       }
       
       match /orders/{orderId} {
-      	allow create,get, update:if true;
-        allow list:if isSignedIn() && (isCustomer() || isAdmin());
-        allow delete:if isSignedIn() && isAdmin();
+        allow create: if isSignedIn();
+        allow get, update: if isSignedIn() && (isCustomer() || isAdmin());
+        allow list: if isSignedIn() && (isCustomer() || isAdmin());
+        allow delete: if isSignedIn() && isAdmin();
       }
       
       function isSignedIn() {


### PR DESCRIPTION
## Summary
- `shopping-carts` autorisait lecture/écriture anonyme — corrigé : requiert auth + propriété du panier
- `orders` autorisait création/lecture/modification anonyme — corrigé : tout requiert auth

## Test plan
- [ ] Vérifier que les paniers sont accessibles aux utilisateurs connectés
- [ ] Tester la création de commandes pour les utilisateurs connectés
- [ ] Déployer avec `firebase deploy --only firestore:rules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)