### PR TITLE
refactor: standardize subscriptions with takeUntil and tap

### DIFF
--- a/src/app/components/products/product-list/product-list.component.ts
+++ b/src/app/components/products/product-list/product-list.component.ts
@@ -6,7 +6,7 @@ import { ShoppingCartService } from 'src/app/services/shopping-cart.service';
 import { ColorService } from 'src/app/services/colors.service';
 import { StoneService } from 'src/app/services/stones.service';
 import { environment } from 'src/environments/environment';
-import { map, takeUntil } from 'rxjs/operators';
+import { map, tap, takeUntil } from 'rxjs/operators';
 import { LocationService } from 'src/app/services/location.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { User } from 'src/app/models/user';
@@ -124,8 +124,7 @@ export class ProductListComponent implements OnInit, OnDestroy {
               this.route.params
                 .pipe(
                   takeUntil(this.destroy$),
-                  map((params) => {
-                    // this.reset();
+                  tap((params) => {
                     this.pierreParam = params.pierre;
                     this.category = 'pierre';
                     this.filteredProducts = products
@@ -134,7 +133,6 @@ export class ProductListComponent implements OnInit, OnDestroy {
                         x.stones?.some((s) => s === this.pierreParam),
                       );
                     this.totalCount = this.filteredProducts.length;
-                    // this.getItems();
                   }),
                 )
                 .subscribe();
@@ -143,8 +141,7 @@ export class ProductListComponent implements OnInit, OnDestroy {
               this.route.params
                 .pipe(
                   takeUntil(this.destroy$),
-                  map((params) => {
-                    // this.reset();
+                  tap((params) => {
                     this.couleurParam = params.couleur;
                     this.category = 'couleur';
                     this.filteredProducts = products
@@ -157,7 +154,6 @@ export class ProductListComponent implements OnInit, OnDestroy {
                         ),
                       );
                     this.totalCount = this.filteredProducts.length;
-                    // this.getItems();
                   }),
                 )
                 .subscribe();

--- a/src/app/components/shopping-cart/shopping-cart-details/shopping-cart-details.component.ts
+++ b/src/app/components/shopping-cart/shopping-cart-details/shopping-cart-details.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ShoppingCartService } from 'src/app/services/shopping-cart.service';
-import { Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
-import { map } from 'rxjs/operators';
+import { tap, takeUntil } from 'rxjs/operators';
 import { ShoppingCart } from 'src/app/models/shopping-cart';
 
 @Component({
@@ -11,9 +11,10 @@ import { ShoppingCart } from 'src/app/models/shopping-cart';
     styles: [],
     standalone: false
 })
-export class ShoppingCartDetailsComponent implements OnInit {
-  cart;
-  subscription: Subscription;
+export class ShoppingCartDetailsComponent implements OnInit, OnDestroy {
+  cart: ShoppingCart;
+  private destroy$ = new Subject<void>();
+
   constructor(
     private cartService: ShoppingCartService,
     private route: ActivatedRoute
@@ -22,9 +23,17 @@ export class ShoppingCartDetailsComponent implements OnInit {
   ngOnInit() {
     const cartId = this.route.snapshot.paramMap.get('id');
 
-    this.subscription = this.cartService
+    this.cartService
       .getItems(cartId)
-      .pipe(map((items: any) => (this.cart = new ShoppingCart(items))))
+      .pipe(
+        tap((items) => (this.cart = new ShoppingCart(items))),
+        takeUntil(this.destroy$),
+      )
       .subscribe();
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }


### PR DESCRIPTION
## Summary
- `shopping-cart-details` : remplace `Subscription.unsubscribe()` manuel par `Subject + takeUntil`, ajoute `OnDestroy` manquant, type `cart: ShoppingCart`
- `shopping-cart-details` : remplace `map` (side effect) par `tap`
- `product-list` : remplace `map` par `tap` dans les subscriptions `route.params`

## Test plan
- [ ] Naviguer vers la page détail d'un panier et vérifier les items
- [ ] Tester le filtrage par pierre et couleur dans la liste produits

🤖 Generated with [Claude Code](https://claude.com/claude-code)